### PR TITLE
Fix order-dependent test by fixing a precondition

### DIFF
--- a/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/test/java/com/alibaba/cloud/nacos/configdata/NacosConfigDataLocationResolverTest.java
+++ b/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/test/java/com/alibaba/cloud/nacos/configdata/NacosConfigDataLocationResolverTest.java
@@ -63,6 +63,12 @@ public class NacosConfigDataLocationResolverTest {
 	@BeforeEach
 	void setup() {
 		this.environment = new MockEnvironment();
+		environment.setProperty("spring.cloud.nacos.username", "root");
+		environment.setProperty("spring.cloud.nacos.password", "root");
+		environment.setProperty("spring.cloud.nacos.config.password", "not_root");
+		environment.setProperty("spring.cloud.nacos.server-addr", "127.0.0.1:8888");
+		environment.setProperty("spring.cloud.nacos.config.server-addr",
+				"127.0.0.1:9999");
 		this.environmentBinder = Binder.get(this.environment);
 		this.resolver = new NacosConfigDataLocationResolver(new DeferredLogs());
 		when(bootstrapContext.isRegistered(eq(ConfigService.class))).thenReturn(true);
@@ -166,7 +172,10 @@ public class NacosConfigDataLocationResolverTest {
 	void testSetCommonPropertiesIsOK() {
 		environment.setProperty("spring.cloud.nacos.username", "root");
 		environment.setProperty("spring.cloud.nacos.password", "root");
+		environment.setProperty("spring.cloud.nacos.config.password", "root");
 		environment.setProperty("spring.cloud.nacos.server-addr", "127.0.0.1:8888");
+		environment.setProperty("spring.cloud.nacos.config.server-addr",
+			"127.0.0.1:8888");
 		String locationUri = "nacos:test.yml";
 		List<NacosConfigDataResource> resources = testUri(locationUri);
 


### PR DESCRIPTION
### Describe what this PR does / why we need it
This PR fix three order-dependent tests by always executing a precondition first.

Related test:
[com.alibaba.cloud.nacos.configdata.NacosConfigDataLocationResolverTest.testDataIdMustBeSpecified](https://github.com/lxb007981/spring-cloud-alibaba/blob/6843cb06da903c39527705e07c16a0e17a06e873/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/test/java/com/alibaba/cloud/nacos/configdata/NacosConfigDataLocationResolverTest.java#L117)
[com.alibaba.cloud.nacos.configdata.NacosConfigDataLocationResolverTest.whenCustomizeSuffix_thenOverrideDefault](https://github.com/lxb007981/spring-cloud-alibaba/blob/6843cb06da903c39527705e07c16a0e17a06e873/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/test/java/com/alibaba/cloud/nacos/configdata/NacosConfigDataLocationResolverTest.java#L130)
[com.alibaba.cloud.nacos.configdata.NacosConfigDataLocationResolverTest.whenNoneInBootstrapContext_thenCreateNewConfigClientProperties](https://github.com/lxb007981/spring-cloud-alibaba/blob/6843cb06da903c39527705e07c16a0e17a06e873/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/test/java/com/alibaba/cloud/nacos/configdata/NacosConfigDataLocationResolverTest.java#L207)

These three tests need to be run after the test [com.alibaba.cloud.nacos.configdata.NacosConfigDataLocationResolverTest.testCommonPropertiesHasLowerPriority](https://github.com/lxb007981/spring-cloud-alibaba/blob/6843cb06da903c39527705e07c16a0e17a06e873/spring-cloud-alibaba-starters/spring-cloud-starter-alibaba-nacos-config/src/test/java/com/alibaba/cloud/nacos/configdata/NacosConfigDataLocationResolverTest.java#L181). 
In other words, these three tests are victims of this polluter test. In the original execution plan, the order is not explicitly specified.

### Does this pull request fix one issue?

NONE

### Describe how you did it

By using the JUnit `@TestMethodOrder(OrderAnnotation.class)` annotation, we can use `@Order(1)` to mark the polluter test, so that other tests always run after this polluter test.

### Describe how to verify it

Using a test order randomizer can trigger this order-dependent flakiness. To verify it manually, mark the polluter test as `Order(2)` and victim tests as `@Order(1)` can demonstrate this flakiness.

### Special notes for reviews
